### PR TITLE
Experimented - solving gRPC conflicts

### DIFF
--- a/Source/KSCrash/llvm/ADT/KZOptional.h
+++ b/Source/KSCrash/llvm/ADT/KZOptional.h
@@ -1,4 +1,4 @@
-//===-- Optional.h - Simple variant for passing optional values ---*- C++ -*-=//
+//===-- KZOptional.h - Simple variant for passing optional values ---*- C++ -*-=//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,14 +7,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  This file provides Optional, a template class modeled in the spirit of
+//  This file provides KZOptional, a template class modeled in the spirit of
 //  OCaml's 'opt' variant.  The idea is to strongly type whether or not
 //  a value can be optional.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_ADT_OPTIONAL_H
-#define LLVM_ADT_OPTIONAL_H
+#ifndef LLVM_ADT_KZOPTIONAL_H
+#define LLVM_ADT_KZOPTIONAL_H
 
 #include "None.h"
 #include "AlignOf.h"
@@ -26,32 +26,32 @@
 namespace llvm {
 
 template<typename T>
-class Optional {
+class KZOptional {
   AlignedCharArrayUnion<T> storage;
   bool hasVal;
 public:
   typedef T value_type;
 
-  Optional(NoneType) : hasVal(false) {}
-  explicit Optional() : hasVal(false) {}
-  Optional(const T &y) : hasVal(true) {
+  KZOptional(NoneType) : hasVal(false) {}
+  explicit KZOptional() : hasVal(false) {}
+  KZOptional(const T &y) : hasVal(true) {
     new (storage.buffer) T(y);
   }
-  Optional(const Optional &O) : hasVal(O.hasVal) {
+  KZOptional(const KZOptional &O) : hasVal(O.hasVal) {
     if (hasVal)
       new (storage.buffer) T(*O);
   }
 
-  Optional(T &&y) : hasVal(true) {
+  KZOptional(T &&y) : hasVal(true) {
     new (storage.buffer) T(std::forward<T>(y));
   }
-  Optional(Optional<T> &&O) : hasVal(O) {
+  KZOptional(KZOptional<T> &&O) : hasVal(O) {
     if (O) {
       new (storage.buffer) T(std::move(*O));
       O.reset();
     }
   }
-  Optional &operator=(T &&y) {
+  KZOptional &operator=(T &&y) {
     if (hasVal)
       **this = std::move(y);
     else {
@@ -60,7 +60,7 @@ public:
     }
     return *this;
   }
-  Optional &operator=(Optional &&O) {
+  KZOptional &operator=(KZOptional &&O) {
     if (!O)
       reset();
     else {
@@ -78,16 +78,16 @@ public:
     new (storage.buffer) T(std::forward<ArgTypes>(Args)...);
   }
 
-  static inline Optional create(const T* y) {
-    return y ? Optional(*y) : Optional();
+  static inline KZOptional create(const T* y) {
+    return y ? KZOptional(*y) : KZOptional();
   }
 
-  // FIXME: these assignments (& the equivalent const T&/const Optional& ctors)
+  // FIXME: these assignments (& the equivalent const T&/const KZOptional& ctors)
   // could be made more efficient by passing by value, possibly unifying them
   // with the rvalue versions above - but this could place a different set of
   // requirements (notably: the existence of a default ctor) when implemented
   // in that way. Careful SFINAE to avoid such pitfalls would be required.
-  Optional &operator=(const T &y) {
+  KZOptional &operator=(const T &y) {
     if (hasVal)
       **this = y;
     else {
@@ -97,7 +97,7 @@ public:
     return *this;
   }
 
-  Optional &operator=(const Optional &O) {
+  KZOptional &operator=(const KZOptional &O) {
     if (!O)
       reset();
     else
@@ -112,7 +112,7 @@ public:
     }
   }
 
-  ~Optional() {
+  ~KZOptional() {
     reset();
   }
 
@@ -145,83 +145,83 @@ public:
 };
 
 template <typename T> struct isPodLike;
-template <typename T> struct isPodLike<Optional<T> > {
-  // An Optional<T> is pod-like if T is.
+template <typename T> struct isPodLike<KZOptional<T> > {
+  // An KZOptional<T> is pod-like if T is.
   static const bool value = isPodLike<T>::value;
 };
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
+/// \brief Poison comparison between two \c KZOptional objects. Clients needs to
+/// explicitly compare the underlying values and account for empty \c KZOptional
 /// objects.
 ///
 /// This routine will never be defined. It returns \c void to help diagnose
 /// errors at compile time.
 template<typename T, typename U>
-void operator==(const Optional<T> &X, const Optional<U> &Y);
+void operator==(const KZOptional<T> &X, const KZOptional<U> &Y);
 
 template<typename T>
-bool operator==(const Optional<T> &X, NoneType) {
+bool operator==(const KZOptional<T> &X, NoneType) {
   return !X.hasValue();
 }
 
 template<typename T>
-bool operator==(NoneType, const Optional<T> &X) {
+bool operator==(NoneType, const KZOptional<T> &X) {
   return X == None;
 }
 
 template<typename T>
-bool operator!=(const Optional<T> &X, NoneType) {
+bool operator!=(const KZOptional<T> &X, NoneType) {
   return !(X == None);
 }
 
 template<typename T>
-bool operator!=(NoneType, const Optional<T> &X) {
+bool operator!=(NoneType, const KZOptional<T> &X) {
   return X != None;
 }
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
+/// \brief Poison comparison between two \c KZOptional objects. Clients needs to
+/// explicitly compare the underlying values and account for empty \c KZOptional
 /// objects.
 ///
 /// This routine will never be defined. It returns \c void to help diagnose
 /// errors at compile time.
 template<typename T, typename U>
-void operator!=(const Optional<T> &X, const Optional<U> &Y);
+void operator!=(const KZOptional<T> &X, const KZOptional<U> &Y);
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
+/// \brief Poison comparison between two \c KZOptional objects. Clients needs to
+/// explicitly compare the underlying values and account for empty \c KZOptional
 /// objects.
 ///
 /// This routine will never be defined. It returns \c void to help diagnose
 /// errors at compile time.
 template<typename T, typename U>
-void operator<(const Optional<T> &X, const Optional<U> &Y);
+void operator<(const KZOptional<T> &X, const KZOptional<U> &Y);
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
+/// \brief Poison comparison between two \c KZOptional objects. Clients needs to
+/// explicitly compare the underlying values and account for empty \c KZOptional
 /// objects.
 ///
 /// This routine will never be defined. It returns \c void to help diagnose
 /// errors at compile time.
 template<typename T, typename U>
-void operator<=(const Optional<T> &X, const Optional<U> &Y);
+void operator<=(const KZOptional<T> &X, const KZOptional<U> &Y);
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
+/// \brief Poison comparison between two \c KZOptional objects. Clients needs to
+/// explicitly compare the underlying values and account for empty \c KZOptional
 /// objects.
 ///
 /// This routine will never be defined. It returns \c void to help diagnose
 /// errors at compile time.
 template<typename T, typename U>
-void operator>=(const Optional<T> &X, const Optional<U> &Y);
+void operator>=(const KZOptional<T> &X, const KZOptional<U> &Y);
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
+/// \brief Poison comparison between two \c KZOptional objects. Clients needs to
+/// explicitly compare the underlying values and account for empty \c KZOptional
 /// objects.
 ///
 /// This routine will never be defined. It returns \c void to help diagnose
 /// errors at compile time.
 template<typename T, typename U>
-void operator>(const Optional<T> &X, const Optional<U> &Y);
+void operator>(const KZOptional<T> &X, const KZOptional<U> &Y);
 
 } // end llvm namespace
 

--- a/Source/KSCrash/llvm/ADT/KZStringRef.h
+++ b/Source/KSCrash/llvm/ADT/KZStringRef.h
@@ -1,4 +1,4 @@
-//===--- StringRef.h - Constant String Reference Wrapper --------*- C++ -*-===//
+//===--- KZStringRef.h - Constant String Reference Wrapper --------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_ADT_STRINGREF_H
-#define LLVM_ADT_STRINGREF_H
+#ifndef LLVM_ADT_KZSTRINGREF_H
+#define LLVM_ADT_KZSTRINGREF_H
 
 #include "Compiler.h"
 #include <algorithm>
@@ -23,22 +23,22 @@ namespace llvm {
   class SmallVectorImpl;
   class APInt;
   class hash_code;
-  class StringRef;
+  class KZStringRef;
 
-  /// Helper functions for StringRef::getAsInteger.
-  bool getAsUnsignedInteger(StringRef Str, unsigned Radix,
+  /// Helper functions for KZStringRef::getAsInteger.
+  bool getAsUnsignedInteger(KZStringRef Str, unsigned Radix,
                             unsigned long long &Result);
 
-  bool getAsSignedInteger(StringRef Str, unsigned Radix, long long &Result);
+  bool getAsSignedInteger(KZStringRef Str, unsigned Radix, long long &Result);
 
-  /// StringRef - Represent a constant reference to a string, i.e. a character
+  /// KZStringRef - Represent a constant reference to a string, i.e. a character
   /// array and a length, which need not be null terminated.
   ///
   /// This class does not own the string data, it is expected to be used in
   /// situations where the character data resides in some other buffer, whose
-  /// lifetime extends past that of the StringRef. For this reason, it is not in
-  /// general safe to store a StringRef.
-  class StringRef {
+  /// lifetime extends past that of the KZStringRef. For this reason, it is not in
+  /// general safe to store a KZStringRef.
+  class KZStringRef {
   public:
     typedef const char *iterator;
     typedef const char *const_iterator;
@@ -65,26 +65,26 @@ namespace llvm {
     /// @{
 
     /// Construct an empty string ref.
-    /*implicit*/ StringRef() : Data(nullptr), Length(0) {}
+    /*implicit*/ KZStringRef() : Data(nullptr), Length(0) {}
 
     /// Construct a string ref from a cstring.
-    /*implicit*/ StringRef(const char *Str)
+    /*implicit*/ KZStringRef(const char *Str)
       : Data(Str) {
-        assert(Str && "StringRef cannot be built from a NULL argument");
+        assert(Str && "KZStringRef cannot be built from a NULL argument");
         Length = ::strlen(Str); // invoking strlen(NULL) is undefined behavior
       }
 
     /// Construct a string ref from a pointer and length.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    /*implicit*/ StringRef(const char *data, size_t length)
+    /*implicit*/ KZStringRef(const char *data, size_t length)
       : Data(data), Length(length) {
         assert((data || length == 0) &&
-        "StringRef cannot be built from a NULL argument with non-null length");
+        "KZStringRef cannot be built from a NULL argument with non-null length");
       }
 
     /// Construct a string ref from an std::string.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    /*implicit*/ StringRef(const std::string &Str)
+    /*implicit*/ KZStringRef(const std::string &Str)
       : Data(Str.data()), Length(Str.length()) {}
 
     /// @}
@@ -131,30 +131,30 @@ namespace llvm {
       return Data[Length-1];
     }
 
-    // copy - Allocate copy in Allocator and return StringRef to it.
-    template <typename Allocator> StringRef copy(Allocator &A) const {
+    // copy - Allocate copy in Allocator and return KZStringRef to it.
+    template <typename Allocator> KZStringRef copy(Allocator &A) const {
       char *S = A.template Allocate<char>(Length);
       std::copy(begin(), end(), S);
-      return StringRef(S, Length);
+      return KZStringRef(S, Length);
     }
 
     /// equals - Check for string equality, this is more efficient than
     /// compare() when the relative ordering of inequal strings isn't needed.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    bool equals(StringRef RHS) const {
+    bool equals(KZStringRef RHS) const {
       return (Length == RHS.Length &&
               compareMemory(Data, RHS.Data, RHS.Length) == 0);
     }
 
     /// equals_lower - Check for string equality, ignoring case.
-    bool equals_lower(StringRef RHS) const {
+    bool equals_lower(KZStringRef RHS) const {
       return Length == RHS.Length && compare_lower(RHS) == 0;
     }
 
     /// compare - Compare two strings; the result is -1, 0, or 1 if this string
     /// is lexicographically less than, equal to, or greater than the \p RHS.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    int compare(StringRef RHS) const {
+    int compare(KZStringRef RHS) const {
       // Check the prefix for a mismatch.
       if (int Res = compareMemory(Data, RHS.Data, std::min(Length, RHS.Length)))
         return Res < 0 ? -1 : 1;
@@ -166,11 +166,11 @@ namespace llvm {
     }
 
     /// compare_lower - Compare two strings, ignoring case.
-    int compare_lower(StringRef RHS) const;
+    int compare_lower(KZStringRef RHS) const;
 
     /// compare_numeric - Compare two strings, treating sequences of digits as
     /// numbers.
-    int compare_numeric(StringRef RHS) const;
+    int compare_numeric(KZStringRef RHS) const;
 
     /// \brief Determine the edit distance between this string and another
     /// string.
@@ -190,7 +190,7 @@ namespace llvm {
     /// or (if \p AllowReplacements is \c true) replacements needed to
     /// transform one of the given strings into the other. If zero,
     /// the strings are identical.
-    unsigned edit_distance(StringRef Other, bool AllowReplacements = true,
+    unsigned edit_distance(KZStringRef Other, bool AllowReplacements = true,
                            unsigned MaxEditDistance = 0) const;
 
     /// str - Get the contents as an std::string.
@@ -222,23 +222,23 @@ namespace llvm {
 
     /// Check if this string starts with the given \p Prefix.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    bool startswith(StringRef Prefix) const {
+    bool startswith(KZStringRef Prefix) const {
       return Length >= Prefix.Length &&
              compareMemory(Data, Prefix.Data, Prefix.Length) == 0;
     }
 
     /// Check if this string starts with the given \p Prefix, ignoring case.
-    bool startswith_lower(StringRef Prefix) const;
+    bool startswith_lower(KZStringRef Prefix) const;
 
     /// Check if this string ends with the given \p Suffix.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    bool endswith(StringRef Suffix) const {
+    bool endswith(KZStringRef Suffix) const {
       return Length >= Suffix.Length &&
         compareMemory(end() - Suffix.Length, Suffix.Data, Suffix.Length) == 0;
     }
 
     /// Check if this string ends with the given \p Suffix, ignoring case.
-    bool endswith_lower(StringRef Suffix) const;
+    bool endswith_lower(KZStringRef Suffix) const;
 
     /// @}
     /// @name String Searching
@@ -263,7 +263,7 @@ namespace llvm {
     ///
     /// \returns The index of the first occurrence of \p Str, or npos if not
     /// found.
-    size_t find(StringRef Str, size_t From = 0) const;
+    size_t find(KZStringRef Str, size_t From = 0) const;
 
     /// Search for the last character \p C in the string.
     ///
@@ -284,7 +284,7 @@ namespace llvm {
     ///
     /// \returns The index of the last occurrence of \p Str, or npos if not
     /// found.
-    size_t rfind(StringRef Str) const;
+    size_t rfind(KZStringRef Str) const;
 
     /// Find the first character in the string that is \p C, or npos if not
     /// found. Same as find.
@@ -296,7 +296,7 @@ namespace llvm {
     /// not found.
     ///
     /// Complexity: O(size() + Chars.size())
-    size_t find_first_of(StringRef Chars, size_t From = 0) const;
+    size_t find_first_of(KZStringRef Chars, size_t From = 0) const;
 
     /// Find the first character in the string that is not \p C or npos if not
     /// found.
@@ -306,7 +306,7 @@ namespace llvm {
     /// \p Chars, or npos if not found.
     ///
     /// Complexity: O(size() + Chars.size())
-    size_t find_first_not_of(StringRef Chars, size_t From = 0) const;
+    size_t find_first_not_of(KZStringRef Chars, size_t From = 0) const;
 
     /// Find the last character in the string that is \p C, or npos if not
     /// found.
@@ -318,7 +318,7 @@ namespace llvm {
     /// found.
     ///
     /// Complexity: O(size() + Chars.size())
-    size_t find_last_of(StringRef Chars, size_t From = npos) const;
+    size_t find_last_of(KZStringRef Chars, size_t From = npos) const;
 
     /// Find the last character in the string that is not \p C, or npos if not
     /// found.
@@ -328,7 +328,7 @@ namespace llvm {
     /// npos if not found.
     ///
     /// Complexity: O(size() + Chars.size())
-    size_t find_last_not_of(StringRef Chars, size_t From = npos) const;
+    size_t find_last_not_of(KZStringRef Chars, size_t From = npos) const;
 
     /// @}
     /// @name Helpful Algorithms
@@ -345,7 +345,7 @@ namespace llvm {
 
     /// Return the number of non-overlapped occurrences of \p Str in
     /// the string.
-    size_t count(StringRef Str) const;
+    size_t count(KZStringRef Str) const;
 
     /// Parse the current string as an integer of the specified radix.  If
     /// \p Radix is specified as zero, this does radix autosensing using
@@ -415,23 +415,23 @@ namespace llvm {
     /// exceeds the number of characters remaining in the string, the string
     /// suffix (starting with \p Start) will be returned.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    StringRef substr(size_t Start, size_t N = npos) const {
+    KZStringRef substr(size_t Start, size_t N = npos) const {
       Start = std::min(Start, Length);
-      return StringRef(Data + Start, std::min(N, Length - Start));
+      return KZStringRef(Data + Start, std::min(N, Length - Start));
     }
 
-    /// Return a StringRef equal to 'this' but with the first \p N elements
+    /// Return a KZStringRef equal to 'this' but with the first \p N elements
     /// dropped.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    StringRef drop_front(size_t N = 1) const {
+    KZStringRef drop_front(size_t N = 1) const {
       assert(size() >= N && "Dropping more elements than exist");
       return substr(N);
     }
 
-    /// Return a StringRef equal to 'this' but with the last \p N elements
+    /// Return a KZStringRef equal to 'this' but with the last \p N elements
     /// dropped.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    StringRef drop_back(size_t N = 1) const {
+    KZStringRef drop_back(size_t N = 1) const {
       assert(size() >= N && "Dropping more elements than exist");
       return substr(0, size()-N);
     }
@@ -447,10 +447,10 @@ namespace llvm {
     /// number of characters remaining in the string, the string suffix
     /// (starting with \p Start) will be returned.
     LLVM_ATTRIBUTE_ALWAYS_INLINE
-    StringRef slice(size_t Start, size_t End) const {
+    KZStringRef slice(size_t Start, size_t End) const {
       Start = std::min(Start, Length);
       End = std::min(std::max(Start, End), Length);
-      return StringRef(Data + Start, End - Start);
+      return KZStringRef(Data + Start, End - Start);
     }
 
     /// Split into two substrings around the first occurrence of a separator
@@ -463,10 +463,10 @@ namespace llvm {
     ///
     /// \param Separator The character to split on.
     /// \returns The split substrings.
-    std::pair<StringRef, StringRef> split(char Separator) const {
+    std::pair<KZStringRef, KZStringRef> split(char Separator) const {
       size_t Idx = find(Separator);
       if (Idx == npos)
-        return std::make_pair(*this, StringRef());
+        return std::make_pair(*this, KZStringRef());
       return std::make_pair(slice(0, Idx), slice(Idx+1, npos));
     }
 
@@ -480,10 +480,10 @@ namespace llvm {
     ///
     /// \param Separator - The string to split on.
     /// \return - The split substrings.
-    std::pair<StringRef, StringRef> split(StringRef Separator) const {
+    std::pair<KZStringRef, KZStringRef> split(KZStringRef Separator) const {
       size_t Idx = find(Separator);
       if (Idx == npos)
-        return std::make_pair(*this, StringRef());
+        return std::make_pair(*this, KZStringRef());
       return std::make_pair(slice(0, Idx), slice(Idx + Separator.size(), npos));
     }
 
@@ -501,8 +501,8 @@ namespace llvm {
     /// \param Separator - The string to split on.
     /// \param MaxSplit - The maximum number of times the string is split.
     /// \param KeepEmpty - True if empty substring should be added.
-    void split(SmallVectorImpl<StringRef> &A,
-               StringRef Separator, int MaxSplit = -1,
+    void split(SmallVectorImpl<KZStringRef> &A,
+               KZStringRef Separator, int MaxSplit = -1,
                bool KeepEmpty = true) const;
 
     /// Split into substrings around the occurrences of a separator character.
@@ -519,7 +519,7 @@ namespace llvm {
     /// \param Separator - The string to split on.
     /// \param MaxSplit - The maximum number of times the string is split.
     /// \param KeepEmpty - True if empty substring should be added.
-    void split(SmallVectorImpl<StringRef> &A, char Separator, int MaxSplit = -1,
+    void split(SmallVectorImpl<KZStringRef> &A, char Separator, int MaxSplit = -1,
                bool KeepEmpty = true) const;
 
     /// Split into two substrings around the last occurrence of a separator
@@ -532,75 +532,75 @@ namespace llvm {
     ///
     /// \param Separator - The character to split on.
     /// \return - The split substrings.
-    std::pair<StringRef, StringRef> rsplit(char Separator) const {
+    std::pair<KZStringRef, KZStringRef> rsplit(char Separator) const {
       size_t Idx = rfind(Separator);
       if (Idx == npos)
-        return std::make_pair(*this, StringRef());
+        return std::make_pair(*this, KZStringRef());
       return std::make_pair(slice(0, Idx), slice(Idx+1, npos));
     }
 
     /// Return string with consecutive characters in \p Chars starting from
     /// the left removed.
-    StringRef ltrim(StringRef Chars = " \t\n\v\f\r") const {
+    KZStringRef ltrim(KZStringRef Chars = " \t\n\v\f\r") const {
       return drop_front(std::min(Length, find_first_not_of(Chars)));
     }
 
     /// Return string with consecutive characters in \p Chars starting from
     /// the right removed.
-    StringRef rtrim(StringRef Chars = " \t\n\v\f\r") const {
+    KZStringRef rtrim(KZStringRef Chars = " \t\n\v\f\r") const {
       return drop_back(Length - std::min(Length, find_last_not_of(Chars) + 1));
     }
 
     /// Return string with consecutive characters in \p Chars starting from
     /// the left and right removed.
-    StringRef trim(StringRef Chars = " \t\n\v\f\r") const {
+    KZStringRef trim(KZStringRef Chars = " \t\n\v\f\r") const {
       return ltrim(Chars).rtrim(Chars);
     }
 
     /// @}
   };
 
-  /// @name StringRef Comparison Operators
+  /// @name KZStringRef Comparison Operators
   /// @{
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
-  inline bool operator==(StringRef LHS, StringRef RHS) {
+  inline bool operator==(KZStringRef LHS, KZStringRef RHS) {
     return LHS.equals(RHS);
   }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
-  inline bool operator!=(StringRef LHS, StringRef RHS) {
+  inline bool operator!=(KZStringRef LHS, KZStringRef RHS) {
     return !(LHS == RHS);
   }
 
-  inline bool operator<(StringRef LHS, StringRef RHS) {
+  inline bool operator<(KZStringRef LHS, KZStringRef RHS) {
     return LHS.compare(RHS) == -1;
   }
 
-  inline bool operator<=(StringRef LHS, StringRef RHS) {
+  inline bool operator<=(KZStringRef LHS, KZStringRef RHS) {
     return LHS.compare(RHS) != 1;
   }
 
-  inline bool operator>(StringRef LHS, StringRef RHS) {
+  inline bool operator>(KZStringRef LHS, KZStringRef RHS) {
     return LHS.compare(RHS) == 1;
   }
 
-  inline bool operator>=(StringRef LHS, StringRef RHS) {
+  inline bool operator>=(KZStringRef LHS, KZStringRef RHS) {
     return LHS.compare(RHS) != -1;
   }
 
-  inline std::string &operator+=(std::string &buffer, StringRef string) {
+  inline std::string &operator+=(std::string &buffer, KZStringRef string) {
     return buffer.append(string.data(), string.size());
   }
 
   /// @}
 
-  /// \brief Compute a hash_code for a StringRef.
-  hash_code hash_value(StringRef S);
+  /// \brief Compute a hash_code for a KZStringRef.
+  hash_code hash_value(KZStringRef S);
 
-  // StringRefs can be treated like a POD type.
+  // KZStringRefs can be treated like a POD type.
   template <typename T> struct isPodLike;
-  template <> struct isPodLike<StringRef> { static const bool value = true; };
+  template <> struct isPodLike<KZStringRef> { static const bool value = true; };
 }
 
 #endif

--- a/Source/KSCrash/llvm/ADT/None.h
+++ b/Source/KSCrash/llvm/ADT/None.h
@@ -17,7 +17,7 @@
 #define LLVM_ADT_NONE_H
 
 namespace llvm {
-/// \brief A simple null object to allow implicit construction of Optional<T>
+/// \brief A simple null object to allow implicit construction of KZOptional<T>
 /// and similar types without having to spell out the specialization's name.
 enum class NoneType { None };
 const NoneType None = None;

--- a/Source/KSCrash/swift/Basic/Demangle.cpp
+++ b/Source/KSCrash/swift/Basic/Demangle.cpp
@@ -20,15 +20,15 @@
 //#include "swift/Basic/LLVM.h"
 //#include "swift/Basic/Punycode.h"
 //#include "swift/Basic/UUID.h"
-//#include "llvm/ADT/StringRef.h"
+//#include "llvm/ADT/KZStringRef.h"
 #include "Demangle.h"
 #include "Fallthrough.h"
 #include "SwiftStrings.h"
 #include "LLVM.h"
 #include "Punycode.h"
 //#include "UUID.h"
-#include "Optional.h"
-#include "StringRef.h"
+#include "KZOptional.h"
+#include "KZStringRef.h"
 #include <functional>
 #include <inttypes.h>
 #include <vector>
@@ -173,9 +173,9 @@ namespace {
 
 /// A convenient class for parsing characters out of a string.
 class NameSource {
-  StringRef Text;
+  KZStringRef Text;
 public:
-  NameSource(StringRef text) : Text(text) {}
+  NameSource(KZStringRef text) : Text(text) {}
 
   /// Return whether there are at least len characters remaining.
   bool hasAtLeast(size_t len) { return (len <= Text.size()); }
@@ -204,7 +204,7 @@ public:
   }
 
   /// Claim the next few characters if they exactly match the given string.
-  bool nextIf(StringRef str) {
+  bool nextIf(KZStringRef str) {
     if (!Text.startswith(str)) return false;
     advanceOffset(str.size());
     return true;
@@ -212,10 +212,10 @@ public:
 
   /// Return the next len characters without claiming them.  Asserts
   /// that there are at least so many characters.
-  StringRef slice(size_t len) { return Text.substr(0, len); }
+  KZStringRef slice(size_t len) { return Text.substr(0, len); }
 
   /// Return the current string ref without claiming any characters.
-  StringRef str() { return Text; }
+  KZStringRef str() { return Text; }
 
   /// Claim the next len characters.
   void advanceOffset(size_t len) {
@@ -223,14 +223,14 @@ public:
   }
 
   /// Claim and return all the rest of the characters.
-  StringRef getString() {
+  KZStringRef getString() {
     auto result = Text;
     advanceOffset(Text.size());
     return result;
   }
 
   bool readUntil(char c, std::string &result) {
-    llvm::Optional<char> c2;
+    llvm::KZOptional<char> c2;
     while (!isEmpty() && (c2 = peek()).getValue() != c) {
       result.push_back(c2.getValue());
       advanceOffset(1);
@@ -239,7 +239,7 @@ public:
   }
 };
 
-static StringRef toString(Directness d) {
+static KZStringRef toString(Directness d) {
   switch (d) {
   case Directness::Direct:
     return "direct";
@@ -249,7 +249,7 @@ static StringRef toString(Directness d) {
   unreachable("bad directness");
 }
 
-static StringRef toString(ValueWitnessKind k) {
+static KZStringRef toString(ValueWitnessKind k) {
   switch (k) {
   case ValueWitnessKind::AllocateBuffer:
     return "allocateBuffer";
@@ -302,7 +302,7 @@ class Demangler {
   std::vector<NodePointer> Substitutions;
   NameSource Mangled;
 public:  
-  Demangler(llvm::StringRef mangled) : Mangled(mangled) {}
+  Demangler(llvm::KZStringRef mangled) : Mangled(mangled) {}
 
 /// Try to demangle a child node of the given kind.  If that fails,
 /// return; otherwise add it to the parent.
@@ -380,7 +380,7 @@ private:
     yes = true, no = false
   };
 
-  Optional<Directness> demangleDirectness() {
+  KZOptional<Directness> demangleDirectness() {
     if (Mangled.nextIf('d'))
       return Directness::Direct;
     if (Mangled.nextIf('i'))
@@ -417,7 +417,7 @@ private:
     return false;
   }
 
-  Optional<ValueWitnessKind> demangleValueWitnessKind() {
+  KZOptional<ValueWitnessKind> demangleValueWitnessKind() {
     if (!Mangled)
       return None;
     char c1 = Mangled.next();
@@ -539,7 +539,7 @@ private:
 
     // Value witnesses.
     if (Mangled.nextIf('w')) {
-      Optional<ValueWitnessKind> w = demangleValueWitnessKind();
+      KZOptional<ValueWitnessKind> w = demangleValueWitnessKind();
       if (!w.hasValue())
         return nullptr;
       auto witness =
@@ -917,14 +917,14 @@ private:
     return demangleIdentifier();
   }
 
-  NodePointer demangleIdentifier(Optional<Node::Kind> kind = None) {
+  NodePointer demangleIdentifier(KZOptional<Node::Kind> kind = None) {
     if (!Mangled)
       return nullptr;
     
     bool isPunycoded = Mangled.nextIf('X');
     std::string decodeBuffer;
 
-    auto decode = [&](StringRef s) -> StringRef {
+    auto decode = [&](KZStringRef s) -> KZStringRef {
       if (!isPunycoded)
         return s;
       if (!Punycode::decodePunycodeUTF8(s, decodeBuffer))
@@ -963,7 +963,7 @@ private:
     if (!Mangled.hasAtLeast((size_t)length))
       return nullptr;
     
-    StringRef identifier = Mangled.slice((size_t)length);
+    KZStringRef identifier = Mangled.slice((size_t)length);
     Mangled.advanceOffset((size_t)length);
     
     // Decode Unicode identifiers.
@@ -1019,7 +1019,7 @@ private:
     return NodeFactory::create(kind, index);
   }
 
-  NodePointer createSwiftType(Node::Kind typeKind, StringRef name) {
+  NodePointer createSwiftType(Node::Kind typeKind, KZStringRef name) {
     NodePointer type = NodeFactory::create(typeKind);
     type->addChild(NodeFactory::create(Node::Kind::Module, STDLIB_NAME));
     type->addChild(NodeFactory::create(Node::Kind::Identifier, name));
@@ -2197,7 +2197,7 @@ private:
   /// impl-convention ::= 'o'                     // direct, ownership transfer
   ///
   /// Returns an empty string otherwise.
-  StringRef demangleImplConvention(ImplConventionContext ctxt) {
+  KZStringRef demangleImplConvention(ImplConventionContext ctxt) {
 #define CASE(CHAR, FOR_CALLEE, FOR_PARAMETER, FOR_RESULT)            \
     if (Mangled.nextIf(CHAR)) {                                      \
       switch (ctxt) {                                                \
@@ -2207,7 +2207,7 @@ private:
       }                                                              \
       unreachable("bad context");                               \
     }
-    auto Nothing = StringRef();
+    auto Nothing = KZStringRef();
     CASE('a',   Nothing,                Nothing,         "@autoreleased")
     CASE('d',   "@callee_unowned",      "@unowned",      "@unowned")
     CASE('D',   Nothing,                Nothing,         "@unowned_inner_pointer")
@@ -2223,7 +2223,7 @@ private:
   // impl-callee-convention ::= 't'
   // impl-callee-convention ::= impl-convention
   bool demangleImplCalleeConvention(NodePointer type) {
-    StringRef attr;
+    KZStringRef attr;
     if (Mangled.nextIf('t')) {
       attr = "@convention(thin)";
     } else {
@@ -2236,7 +2236,7 @@ private:
     return true;
   }
 
-  void addImplFunctionAttribute(NodePointer parent, StringRef attr,
+  void addImplFunctionAttribute(NodePointer parent, KZStringRef attr,
                          Node::Kind kind = Node::Kind::ImplFunctionAttribute) {
     parent->addChild(NodeFactory::create(kind, attr));
   }
@@ -2298,7 +2298,7 @@ NodePointer
 swift::Demangle::demangleSymbolAsNode(const char *MangledName,
                                       size_t MangledNameLength,
                                       __unused const DemangleOptions &Options) {
-  Demangler demangler(StringRef(MangledName, MangledNameLength));
+  Demangler demangler(KZStringRef(MangledName, MangledNameLength));
   return demangler.demangleTopLevel();
 }
 
@@ -2306,7 +2306,7 @@ NodePointer
 swift::Demangle::demangleTypeAsNode(const char *MangledName,
                                     size_t MangledNameLength,
                                     __unused const DemangleOptions &Options) {
-  Demangler demangler(StringRef(MangledName, MangledNameLength));
+  Demangler demangler(KZStringRef(MangledName, MangledNameLength));
   return demangler.demangleTypeName();
 }
 
@@ -2373,7 +2373,7 @@ private:
               0 == node->getText().find(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX));
     }
 
-  static bool isIdentifier(NodePointer node, StringRef desired) {
+  static bool isIdentifier(NodePointer node, KZStringRef desired) {
     return (node->getKind() == Node::Kind::Identifier &&
             node->getText() == desired);
   }
@@ -2886,7 +2886,7 @@ void NodePrinter::printSimplifiedEntityType(NodePointer context,
 
 void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) {
   // Common code for handling entities.
-  auto printEntity = [&](bool hasName, bool hasType, StringRef extraName) {
+  auto printEntity = [&](bool hasName, bool hasType, KZStringRef extraName) {
     if (Options.QualifyEntities)
       printContext(pointer->getChild(0));
 
@@ -3712,7 +3712,7 @@ std::string Demangle::nodeToString(NodePointer root,
 std::string Demangle::demangleSymbolAsString(const char *MangledName,
                                              size_t MangledNameLength,
                                              const DemangleOptions &Options) {
-  auto mangled = StringRef(MangledName, MangledNameLength);
+  auto mangled = KZStringRef(MangledName, MangledNameLength);
   auto root = demangleSymbolAsNode(MangledName, MangledNameLength, Options);
   if (!root) return mangled.str();
 
@@ -3725,7 +3725,7 @@ std::string Demangle::demangleSymbolAsString(const char *MangledName,
 std::string Demangle::demangleTypeAsString(const char *MangledName,
                                            size_t MangledNameLength,
                                            const DemangleOptions &Options) {
-  auto mangled = StringRef(MangledName, MangledNameLength);
+  auto mangled = KZStringRef(MangledName, MangledNameLength);
   auto root = demangleTypeAsNode(MangledName, MangledNameLength, Options);
   if (!root) return mangled.str();
   

--- a/Source/KSCrash/swift/Basic/Demangle.h
+++ b/Source/KSCrash/swift/Basic/Demangle.h
@@ -18,9 +18,9 @@
 #include <vector>
 #include <cassert>
 #include <cstdint>
-//#include "llvm/ADT/StringRef.h"
+//#include "llvm/ADT/KZStringRef.h"
 //#include "swift/Basic/Malloc.h"
-#include "StringRef.h"
+#include "KZStringRef.h"
 #include "Malloc.h"
 
 namespace llvm {
@@ -360,7 +360,7 @@ struct NodeFactory {
   static NodePointer create(Node::Kind K, Node::IndexType Index) {
     return NodePointer(new Node(K, Index));
   }
-  static NodePointer create(Node::Kind K, llvm::StringRef Text) {
+  static NodePointer create(Node::Kind K, llvm::KZStringRef Text) {
     return NodePointer(new Node(K, Text));
   }
   static NodePointer create(Node::Kind K, std::string &&Text) {
@@ -368,7 +368,7 @@ struct NodeFactory {
   }
   template <size_t N>
   static NodePointer create(Node::Kind K, const char (&Text)[N]) {
-    return NodePointer(new Node(K, llvm::StringRef(Text)));
+    return NodePointer(new Node(K, llvm::KZStringRef(Text)));
   }
 };
 
@@ -377,7 +377,7 @@ class DemanglerPrinter {
 public:
   DemanglerPrinter() = default;
 
-  DemanglerPrinter &operator<<(llvm::StringRef Value) & {
+  DemanglerPrinter &operator<<(llvm::KZStringRef Value) & {
     Stream.append(Value.data(), Value.size());
     return *this;
   }

--- a/Source/KSCrash/swift/Basic/LLVM.h
+++ b/Source/KSCrash/swift/Basic/LLVM.h
@@ -31,7 +31,7 @@
 // Forward declarations.
 namespace llvm {
   // Containers.
-  class StringRef;
+  class KZStringRef;
   class Twine;
   template <typename T> class SmallPtrSetImpl;
   template <typename T, unsigned N> class SmallPtrSet;
@@ -41,7 +41,7 @@ namespace llvm {
   template<typename T> class ArrayRef;
   template<typename T> class MutableArrayRef;
   template<typename T> class TinyPtrVector;
-  template<typename T> class Optional;
+  template<typename T> class KZOptional;
   template <typename PT1, typename PT2> class PointerUnion;
 
   // Other common classes.
@@ -61,11 +61,11 @@ namespace swift {
 
   // Containers.
   using llvm::None;
-  using llvm::Optional;
+  using llvm::KZOptional;
   using llvm::SmallPtrSetImpl;
   using llvm::SmallPtrSet;
   using llvm::SmallString;
-  using llvm::StringRef;
+  using llvm::KZStringRef;
   using llvm::Twine;
   using llvm::SmallVectorImpl;
   using llvm::SmallVector;

--- a/Source/KSCrash/swift/Basic/Punycode.cpp
+++ b/Source/KSCrash/swift/Basic/Punycode.cpp
@@ -71,7 +71,7 @@ static int adapt(int delta, int numpoints, bool firsttime) {
 
 // Section 6.2: Decoding procedure
 
-bool Punycode::decodePunycode(StringRef InputPunycode,
+bool Punycode::decodePunycode(KZStringRef InputPunycode,
                               std::vector<uint32_t> &OutCodePoints) {
   OutCodePoints.clear();
   OutCodePoints.reserve(InputPunycode.size());
@@ -84,7 +84,7 @@ bool Punycode::decodePunycode(StringRef InputPunycode,
   // consume all code points before the last delimiter (if there is one)
   //  and copy them to output,
   size_t lastDelimiter = InputPunycode.find_last_of(delimiter);
-  if (lastDelimiter != StringRef::npos) {
+  if (lastDelimiter != KZStringRef::npos) {
     for (char c : InputPunycode.slice(0, lastDelimiter)) {
       // fail on any non-basic code point
       if (static_cast<unsigned char>(c) > 0x7f)
@@ -255,7 +255,7 @@ static bool encodeToUTF8(const std::vector<uint32_t> &Scalars,
   return true;
 }
 
-bool Punycode::decodePunycodeUTF8(StringRef InputPunycode,
+bool Punycode::decodePunycodeUTF8(KZStringRef InputPunycode,
                                   std::string &OutUTF8) {
   std::vector<uint32_t> OutCodePoints;
   if (!decodePunycode(InputPunycode, OutCodePoints))

--- a/Source/KSCrash/swift/Basic/Punycode.h
+++ b/Source/KSCrash/swift/Basic/Punycode.h
@@ -25,10 +25,10 @@
 #define SWIFT_BASIC_PUNYCODE_H
 
 //#include "swift/Basic/LLVM.h"
-//#include "llvm/ADT/StringRef.h"
+//#include "llvm/ADT/KZStringRef.h"
 //#include "llvm/ADT/SmallVector.h"
 #include "LLVM.h"
-#include "StringRef.h"
+#include "KZStringRef.h"
 #include <vector>
 #include <cstdint>
 
@@ -44,12 +44,12 @@ bool encodePunycode(const std::vector<uint32_t> &InputCodePoints,
 /// Decodes a Punycode string into a sequence of Unicode scalars.
 ///
 /// Returns false if decoding failed.
-bool decodePunycode(StringRef InputPunycode,
+bool decodePunycode(KZStringRef InputPunycode,
                     std::vector<uint32_t> &OutCodePoints);
 
-bool encodePunycodeUTF8(StringRef InputUTF8, std::string &OutPunycode);
+bool encodePunycodeUTF8(KZStringRef InputUTF8, std::string &OutPunycode);
 
-bool decodePunycodeUTF8(StringRef InputPunycode, std::string &OutUTF8);
+bool decodePunycodeUTF8(KZStringRef InputPunycode, std::string &OutUTF8);
 
 } // end namespace Punycode
 } // end namespace swift


### PR DESCRIPTION
renamed "Optional" => "KZOptional" and "StringRef" => "KZStringRef" to bypass these conflicts